### PR TITLE
Add file like object to from_avro

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -39,21 +39,27 @@ def __schema_infer(df):
     return schema
 
 
-def from_avro(file_path, schema=None):
+def __file_to_dataframe(f, schema):
+    reader = fastavro.reader(f, reader_schema=schema)
+    return pd.DataFrame.from_records(list(reader))
+
+
+def from_avro(file_path_or_buffer, schema=None):
     """
     Avro file reader.
 
     Args:
-        file_path: Input file path.
+        file_path_or_buffer: Input file path or file-like object.
         schema: Avro schema.
 
     Returns:
         Class of pd.DataFrame.
     """
-
-    with open(file_path, 'rb') as f:
-        reader = fastavro.reader(f, reader_schema=schema)
-        return pd.DataFrame.from_records(list(reader))
+    if isinstance(file_path_or_buffer, str):
+        with open(file_path_or_buffer, 'rb') as f:
+            return __file_to_dataframe(f, schema)
+    else:
+        return __file_to_dataframe(file_path_or_buffer, schema)
 
 
 def to_avro(file_path, df, schema=None):

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pandavro as pdx
 from tempfile import NamedTemporaryFile
 from pandas.util.testing import assert_frame_equal
+from io import BytesIO
 
 
 @pytest.fixture
@@ -40,7 +41,15 @@ def test_fields_infer(dataframe):
     assert expect == pdx.__fields_infer(dataframe)
 
 
-def test_e2e(dataframe):
+def test_buffer_e2e(dataframe):
+    tf = NamedTemporaryFile()
+    pdx.to_avro(tf.name, dataframe)
+    with open(tf.name, 'rb') as f:
+        expect = pdx.from_avro(BytesIO(f.read()))
+    assert_frame_equal(expect, dataframe)
+
+
+def test_file_path_e2e(dataframe):
     tf = NamedTemporaryFile()
     pdx.to_avro(tf.name, dataframe)
     expect = pdx.from_avro(tf.name)


### PR DESCRIPTION
This PR enables to pass file-like object (like BytesIO) to `from_avro`.
An example ( using [google-cloud-python](https://github.com/GoogleCloudPlatform/google-cloud-python) ) is like this.

```python
import pandavro as pdx
from io import BytesIO
from google.cloud import storage

client = storage.Client()
bucket = client.get_bucket('my-bucket')
blob = bucket.get_blob('path/to/sample.avro')
content = blob.download_as_string()
dataframe = pdx.from_avro(BytesIO(content))
```