### PR TITLE
Fix order of test dict entries

### DIFF
--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -9,10 +9,10 @@ from io import BytesIO
 
 @pytest.fixture
 def dataframe():
-    return pd.DataFrame({"String": ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar'],
+    return pd.DataFrame({"Boolean": [True, False, True, False, True, False, True, False],
                          "Float64": np.random.randn(8),
                          "Int64": np.random.randint(0, 10, 8),
-                         "Boolean": [True, False, True, False, True, False, True, False]
+                         "String": ['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar']
                          })
 
 


### PR DESCRIPTION
When running the provided unit tests in Python 3.6 or later, they all fail since the order of the columns for the DataFrames used for testing does not match. This is because since Python 3.6, dict elements remain in the same order in which they are passed to the constructor. This PR fixes the explained issue so that all tests pass again.