### PR TITLE
Adhere to Pandas API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ pip install pandavro
 
 It prepares like pandas APIs:
 
-- `from_avro`
+- `read_avro`
     - Read the records from Avro file and fit them into pandas DataFrame using [fastavro](https://github.com/tebeka/fastavro).
 - `to_avro`
     - Write the rows of pandas DataFrame to Avro file with the original schema infer.
@@ -28,7 +28,7 @@ import pandavro as pdx
 
 
 def main():
-    weather = pdx.from_avro('weather.avro')
+    weather = pdx.read_avro('weather.avro')
 
     print(weather)
 

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -44,7 +44,7 @@ def __file_to_dataframe(f, schema):
     return pd.DataFrame.from_records(list(reader))
 
 
-def from_avro(file_path_or_buffer, schema=None):
+def read_avro(file_path_or_buffer, schema=None):
     """
     Avro file reader.
 
@@ -60,6 +60,22 @@ def from_avro(file_path_or_buffer, schema=None):
             return __file_to_dataframe(f, schema)
     else:
         return __file_to_dataframe(file_path_or_buffer, schema)
+
+
+def from_avro(file_path_or_buffer, schema=None):
+    """
+    Avro file reader.
+
+    Delegates to the `read_avro` method to remain backward compatible.
+
+    Args:
+        file_path_or_buffer: Input file path or file-like object.
+        schema: Avro schema.
+
+    Returns:
+        Class of pd.DataFrame.
+    """
+    return read_avro(file_path_or_buffer, schema)
 
 
 def to_avro(file_path, df, schema=None):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='pandavro',
-    version='1.1.1',
+    version='1.2.0',
     description='The interface between Avro and pandas DataFrame',
     url='https://github.com/ynqa/pandavro',
     author='Makoto Ito',

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -45,11 +45,18 @@ def test_buffer_e2e(dataframe):
     tf = NamedTemporaryFile()
     pdx.to_avro(tf.name, dataframe)
     with open(tf.name, 'rb') as f:
-        expect = pdx.from_avro(BytesIO(f.read()))
+        expect = pdx.read_avro(BytesIO(f.read()))
     assert_frame_equal(expect, dataframe)
 
 
 def test_file_path_e2e(dataframe):
+    tf = NamedTemporaryFile()
+    pdx.to_avro(tf.name, dataframe)
+    expect = pdx.read_avro(tf.name)
+    assert_frame_equal(expect, dataframe)
+
+
+def test_delegation(dataframe):
     tf = NamedTemporaryFile()
     pdx.to_avro(tf.name, dataframe)
     expect = pdx.from_avro(tf.name)


### PR DESCRIPTION
Since version 0.21.0, the `pandas.from_csv()` method is deprecated (see https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.from_csv.html). Instead, the signature `pandas.read_csv()` shall now be used. Consequentially, this PR renames `from_avro()` to `read_avro` but delegates `from_avro()` calls to `read_avro` in order to remain backward compatible.