### PR TITLE
Pandas kwargs

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -39,30 +39,31 @@ def __schema_infer(df):
     return schema
 
 
-def __file_to_dataframe(f, schema):
+def __file_to_dataframe(f, schema, **kwargs):
     reader = fastavro.reader(f, reader_schema=schema)
-    return pd.DataFrame.from_records(list(reader))
+    return pd.DataFrame.from_records(list(reader), **kwargs)
 
 
-def read_avro(file_path_or_buffer, schema=None):
+def read_avro(file_path_or_buffer, schema=None, **kwargs):
     """
     Avro file reader.
 
     Args:
         file_path_or_buffer: Input file path or file-like object.
         schema: Avro schema.
+        **kwargs: Keyword argument to pandas.DataFrame.from_records.
 
     Returns:
         Class of pd.DataFrame.
     """
     if isinstance(file_path_or_buffer, str):
         with open(file_path_or_buffer, 'rb') as f:
-            return __file_to_dataframe(f, schema)
+            return __file_to_dataframe(f, schema, **kwargs)
     else:
-        return __file_to_dataframe(file_path_or_buffer, schema)
+        return __file_to_dataframe(file_path_or_buffer, schema, **kwargs)
 
 
-def from_avro(file_path_or_buffer, schema=None):
+def from_avro(file_path_or_buffer, schema=None, **kwargs):
     """
     Avro file reader.
 
@@ -71,11 +72,12 @@ def from_avro(file_path_or_buffer, schema=None):
     Args:
         file_path_or_buffer: Input file path or file-like object.
         schema: Avro schema.
+        **kwargs: Keyword argument to pandas.DataFrame.from_records.
 
     Returns:
         Class of pd.DataFrame.
     """
-    return read_avro(file_path_or_buffer, schema)
+    return read_avro(file_path_or_buffer, schema, **kwargs)
 
 
 def to_avro(file_path, df, schema=None):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='pandavro',
-    version='1.2.0',
+    version='1.3.0',
     description='The interface between Avro and pandas DataFrame',
     url='https://github.com/ynqa/pandavro',
     author='Makoto Ito',

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -63,5 +63,25 @@ def test_delegation(dataframe):
     assert_frame_equal(expect, dataframe)
 
 
+def test_dataframe_kwargs(dataframe):
+    tf = NamedTemporaryFile()
+    pdx.to_avro(tf.name, dataframe)
+    # include columns
+    columns = ['Boolean', 'Int64']
+    expect = pdx.read_avro(tf.name, columns=columns)
+    df = dataframe[columns]
+    assert_frame_equal(expect, df)
+    # exclude columns
+    columns = ['String', 'Boolean']
+    expect = pdx.read_avro(tf.name, exclude=columns)
+    df = dataframe.drop(columns, axis=1)
+    assert_frame_equal(expect, df)
+    # specify index
+    index = 'String'
+    expect = pdx.read_avro(tf.name, index=index)
+    df = dataframe.set_index(index)
+    assert_frame_equal(expect, df)
+
+
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
For the use case where one wants to construct a `pandas.DataFrame` using only a subset of avro fields (columns), it is more efficient to pass the `columns` kwarg to the `DataFrame.from_records` constructor rather than to load all fields into memory and filter.  Similarly, one might wish to specify fields (columns) to exclude, although this use case is of secondary concern since it is unlikely that such an exclude list would be large enough to realize significant efficiency gains.

This PR exposes the `kwargs` of the `DataFrame.from_records` constructor in the `read_avro`/`from_avro` functions for this purpose.