### PR TITLE
Fix incorrect type inference, Python compatibility issues, support compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+dist: xenial
 language: python
 python:
+- 2.7
 - 3.5
 - 3.6
+- 3.7
 install:
 - pip install -e .[tests]
 script:

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -115,7 +115,7 @@ def from_avro(file_path_or_buffer, schema=None, **kwargs):
     return read_avro(file_path_or_buffer, schema, **kwargs)
 
 
-def to_avro(file_path, df, schema=None):
+def to_avro(file_path, df, schema=None, codec='null'):
     """
     Avro file writer.
 
@@ -124,6 +124,10 @@ def to_avro(file_path, df, schema=None):
         df: pd.DataFrame.
         schema: Dict of Avro schema.
             If it's set None, inferring schema.
+        codec: A string indicating the compression codec to use.
+            Default is no compression ("null"), other acceptable values are
+            "snappy" and "deflate". You must have python-snappy installed to use
+            the snappy codec.
     """
 
     if schema is None:
@@ -131,4 +135,5 @@ def to_avro(file_path, df, schema=None):
 
     with open(file_path, 'wb') as f:
         fastavro.writer(f, schema=schema,
-                        records=df.to_dict('records'))
+                        records=df.to_dict('records'),
+                        codec=codec)

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -126,12 +126,13 @@ def from_avro(file_path_or_buffer, schema=None, **kwargs):
     return read_avro(file_path_or_buffer, schema, **kwargs)
 
 
-def to_avro(file_path, df, schema=None, codec='null'):
+def to_avro(file_path_or_buffer, df, schema=None, codec='null'):
     """
     Avro file writer.
 
     Args:
-        file_path: Output file path.
+        file_path_or_buffer:
+            Output file path or file-like object.
         df: pd.DataFrame.
         schema: Dict of Avro schema.
             If it's set None, inferring schema.
@@ -140,11 +141,13 @@ def to_avro(file_path, df, schema=None, codec='null'):
             "snappy" and "deflate". You must have python-snappy installed to use
             the snappy codec.
     """
-
     if schema is None:
         schema = __schema_infer(df)
 
-    with open(file_path, 'wb') as f:
-        fastavro.writer(f, schema=schema,
-                        records=df.to_dict('records'),
-                        codec=codec)
+    if isinstance(file_path_or_buffer, six.string_types):
+        with open(file_path_or_buffer, 'wb') as f:
+            fastavro.writer(f, schema=schema,
+                            records=df.to_dict('records'), codec=codec)
+    else:
+        fastavro.writer(file_path_or_buffer, schema=schema,
+                        records=df.to_dict('records'), codec=codec)

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -6,14 +6,14 @@ import six
 
 try:
     # Pandas <= 0.23
-    from pandas.core.dtypes.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
+    from pandas.core.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
 except ImportError:
     # Pandas >= 0.24
     from pandas import DatetimeTZDtype
 
 
-DTYPE_TO_AVRO_TYPE = {
-    np.bool_: 'boolean',
+SIMPLE_AVRO_TYPES = {
+    np.dtype('?'): 'boolean',
     np.int8: 'int',
     np.int16: 'int',
     np.int32: 'int',
@@ -22,45 +22,62 @@ DTYPE_TO_AVRO_TYPE = {
     np.uint32: 'int',
     np.int64: 'long',
     np.uint64: 'long',
-    np.object_: 'string',
+    np.dtype('O'): 'string',  # FIXME: Don't automatically store objects as strings
     np.unicode_: 'string',
     np.float32: 'float',
     np.float64: 'double',
-    np.datetime64: {'type': 'long', 'logicalType': 'timestamp-micros'},
-    DatetimeTZDtype: {'type': 'long', 'logicalType': 'timestamp-micros'},
-    np.void: 'binary',
-    np.bytes_: 'binary',
+}
+
+
+COMPLEX_AVRO_TYPES = {
+    np.datetime64: {'type': ['null', 'long'], 'logicalType': 'timestamp-micros'},
+    DatetimeTZDtype: {'type': ['null', 'long'], 'logicalType': 'timestamp-micros'},
+    pd.Timestamp: {'type': ['null', 'long'], 'logicalType': 'timestamp-micros'},
 }
 
 
 # Pandas 0.24 added support for nullable integers. Include those in the supported
 # integer dtypes if present, otherwise ignore them.
 try:
-    DTYPE_TO_AVRO_TYPE[pd.Int8Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.Int16Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.Int32Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.UInt8Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.UInt16Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.UInt32Dtype] = 'int'
-    DTYPE_TO_AVRO_TYPE[pd.UInt64Dtype] = 'long'
-    DTYPE_TO_AVRO_TYPE[pd.Int64Dtype] = 'long'
+    SIMPLE_AVRO_TYPES[pd.Int8Dtype] = 'int'
+    SIMPLE_AVRO_TYPES[pd.Int16Dtype] = 'int'
+    SIMPLE_AVRO_TYPES[pd.Int32Dtype] = 'int'
+    SIMPLE_AVRO_TYPES[pd.Int64Dtype] = 'long'
+
+    # We need the non-standard `unsigned` flag because Avro doesn't support
+    # unsigned integers, and we have no other way of indicating that the loaded
+    # integer is supposed to be unsigned.
+    COMPLEX_AVRO_TYPES[pd.UInt8Dtype] = {'type': 'int', 'unsigned': True}
+    COMPLEX_AVRO_TYPES[pd.UInt16Dtype] = {'type': 'int', 'unsigned': True}
+    COMPLEX_AVRO_TYPES[pd.UInt32Dtype] = {'type': 'int', 'unsigned': True}
+    COMPLEX_AVRO_TYPES[pd.UInt64Dtype] = {'type': 'long', 'unsigned': True}
 except AttributeError:
     pass
 
 
 def __type_infer(t):
-    if t in DTYPE_TO_AVRO_TYPE:
-        return DTYPE_TO_AVRO_TYPE[t]
-    elif getattr(t, 'type', None) in DTYPE_TO_AVRO_TYPE:
-        return DTYPE_TO_AVRO_TYPE[t.type]
+    # Binary data has to be handled separately from the other dtypes because it
+    # requires a parameter, the buffer size.
+    if t is np.void:
+        return {
+            'type': 'fixed',
+            'size': t.itemsize,
+        }
+
+    if t in SIMPLE_AVRO_TYPES:
+        return ['null', SIMPLE_AVRO_TYPES[t]]
+    if t in COMPLEX_AVRO_TYPES:
+        return COMPLEX_AVRO_TYPES[t]
+    if hasattr(t, 'type'):
+        return __type_infer(t.type)
+
     raise TypeError('Invalid type: {}'.format(t))
 
 
 def __fields_infer(df):
     fields = []
     for key, type_np in six.iteritems(df.dtypes):
-        type_avro = __type_infer(type_np)
-        fields.append({'name': key, 'type': ['null', type_avro]})
+        fields.append({'name': key, 'type': __type_infer(type_np)})
     return fields
 
 

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -3,6 +3,14 @@ import numpy as np
 import pandas as pd
 import six
 
+try:
+    # Pandas <= 0.23
+    from pandas.core.dtypes.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
+except ImportError:
+    # Pandas >= 0.24
+    from pandas import DatetimeTZDtype
+
+
 # Pandas 0.24 added support for nullable integers. Include those in the supported
 # integer dtypes if present, otherwise ignore them.
 try:

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -35,7 +35,7 @@ def __type_infer(t):
     elif t in (np.object_, np.unicode_):
         # TODO: Dealing with the case of collection.
         return 'string'
-    elif t.type in (np.datetime64, pd.core.dtypes.dtypes.DatetimeTZDtypeType):
+    elif t.type in (np.datetime64, pd.DatetimeTZDtype):
         # https://avro.apache.org/docs/current/spec.html#Timestamp+%28microsecond+precision%29)
         return {'type': 'long', 'logicalType': 'timestamp-micros'}
     else:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,10 @@ setup(
         'fastavro>=0.14.7',
         'numpy',
         'pandas',
+        'six>=1.9',
     ],
     extras_require={
         'tests': ['pytest'],
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='pandavro',
-    version='1.4.0',
+    version='1.5.0',
     description='The interface between Avro and pandas DataFrame',
     url='https://github.com/ynqa/pandavro',
     author='Makoto Ito',

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     license='MIT',
     packages=find_packages(exclude=['example']),
     install_requires=[
-        'fastavro>=0.14.7',
-        'numpy',
+        'fastavro>=0.14.11',
+        'numpy>=1.7.0',
         'pandas',
         'six>=1.9',
     ],


### PR DESCRIPTION
# New features

* Added support for unsigned integer types, which were not detected
* Added support for Pandas' [nullable integer datatypes](https://pandas.pydata.org/pandas-docs/stable/user_guide/integer_na.html) introduced in 0.24.
* Added support for binary data types
* `to_avro` now accepts file-like objects in addition to a file path.
* Added support for compression codecs

# Bugfixes

## Type inference

* `__type_infer` had a bug where only the `int8` dtype was detected, `int16` and `int32` weren't. The equality comparison should've used `in` and a tuple rather than a parenthesized boolean expression.

Original code:

```py
>>> import numpy as np                                                                                                                                                                                                         

>>> np.int8 == (np.int8 or np.int16 or np.int32)                                                                                                                                                                               
True

# This is wrong
>>> np.int16 == (np.int8 or np.int16 or np.int32)                                                                                                                                                                              
False
```

* Fixed reference to `DatetimeTZDtypeType` which was moved and renamed in Pandas 0.24.

## Python compatibility bugs

* Removed type annotations which were incompatible with Python 3.5 and lower
* Fixed use of `iteritems()` in  `__fields_infer()` which is incompatible with Python 3
* Fixed type detection for file path argument in `read_avro` so that unicode strings could be used on Python 2

## Testing

* Test on all supported versions of Python
* Add 3.7 as a new version