### PR TITLE
fixes import

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -5,7 +5,7 @@ import six
 
 try:
     # Pandas <= 0.23
-    from pandas.core.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
+    from pandas.core.dtypes.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
 except ImportError:
     # Pandas >= 0.24
     from pandas import DatetimeTZDtype


### PR DESCRIPTION
When running on Pandas 0.23.4, I can't import without making the slight change in this commit. It seems to be correct for the latest version of Pandas as well - the `DatetimeTZDtype` is in the same location:

https://github.com/pandas-dev/pandas/blob/master/pandas/core/dtypes/dtypes.py#L616