### PR TITLE
Adding option for time data types to be encoded as milliseconds

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import fastavro
 import numpy as np
 import pandas as pd
@@ -72,13 +70,10 @@ def __type_infer(t):
 
 
 def __fields_infer(df):
-    # print(NUMPY_TO_AVRO_TYPES)
-    x = [
+    return [
         {'name': key, 'type': __type_infer(type_np)}
         for key, type_np in six.iteritems(df.dtypes)
     ]
-    # print(NUMPY_TO_AVRO_TYPES)
-    return x
 
 
 def __schema_infer(df, times_as_micros):

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -60,7 +60,11 @@ def __type_infer(t):
         }
 
     if t in NUMPY_TO_AVRO_TYPES:
-        return ['null', NUMPY_TO_AVRO_TYPES[t]]
+        avro_type = NUMPY_TO_AVRO_TYPES[t]
+        if isinstance(avro_type, dict):
+            # To ensure that the global is unmodified if millis are inserted
+            avro_type = avro_type.copy()
+        return ['null', avro_type]
     if hasattr(t, 'type'):
         return __type_infer(t.type)
 
@@ -68,10 +72,13 @@ def __type_infer(t):
 
 
 def __fields_infer(df):
-    return [
+    # print(NUMPY_TO_AVRO_TYPES)
+    x = [
         {'name': key, 'type': __type_infer(type_np)}
         for key, type_np in six.iteritems(df.dtypes)
     ]
+    # print(NUMPY_TO_AVRO_TYPES)
+    return x
 
 
 def __schema_infer(df, times_as_micros):
@@ -82,8 +89,7 @@ def __schema_infer(df, times_as_micros):
         'fields': fields
     }
 
-    # Patch 'timestamp-millis' in, leaving the default global
-    # NUMPY_TO_AVRO_TYPES unmodified
+    # Patch 'timestamp-millis' in
     if not times_as_micros:
         for field in schema['fields']:
             non_null_type = field['type'][1]
@@ -150,7 +156,7 @@ def to_avro(file_path_or_buffer, df, schema=None, append=False,
 
     """
     if schema is None:
-        schema = __schema_infer(df)
+        schema = __schema_infer(df, times_as_micros)
 
     open_mode = 'wb' if not append else 'a+b'
 

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -33,7 +33,24 @@ def test_schema_infer(dataframe):
                 {'type': ['null', 'string'], 'name': 'String'},
             ]
     }
-    assert expect == pdx.__schema_infer(dataframe)
+    assert expect == pdx.__schema_infer(dataframe, times_as_micros=True)
+
+
+def test_schema_infer_times_as_millis(dataframe):
+    expect = {
+        'type': 'record',
+        'name': 'Root',
+        'fields':
+            [
+                {'type': ['null', 'boolean'], 'name': 'Boolean'},
+                {'type': ['null', {'logicalType': 'timestamp-millis', 'type': 'long'}],
+                    'name': 'DateTime64'},
+                {'type': ['null', 'double'], 'name': 'Float64'},
+                {'type': ['null', 'long'], 'name': 'Int64'},
+                {'type': ['null', 'string'], 'name': 'String'},
+            ]
+    }
+    assert expect == pdx.__schema_infer(dataframe, times_as_micros=False)
 
 
 def test_fields_infer(dataframe):


### PR DESCRIPTION
Currently, a hard assumption is made in `NUMPY_TO_AVRO_TYPES` about the `logicalType` of time types (`pd.datetime64`, `DatetimeTZDtype`, and `pd.Timestamp`) - it is hard coded to microseconds. Certain platforms (specifically, a Hive based data lake in my case) expect timestamps in Avro files to be encoded as milliseconds. This option would allow users like myself to ensure that columns of time types are written in a way that their destination platform can interpret.

I do not feel that this solution is the most elegant solution possible, _but_ it alters the external behavior/API and expected user behavior the least. I would be more than open to suggestions on alternative ways to implement this if those things are not as important as I planned for (or if someone just simply has a better idea than me).

I'll also take the opportunity to say: Thank you to the contributors of this package - it's made my life a lot easier, and has taught me a great deal about interacting with Avro as a whole.