### PR TITLE
Feature/add pandas1 dtypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ Pandavro can handle these primitive types:
 | np.int8, np.int16, np.int32                   | int                 |
 | np.uint8, np.uint16, np.uint32                | int                 |
 | np.int64, np.uint64                           | long                |
-| pd.Int8Dtype, pd.Int16Dtype, pd.Int32Dtype    | int                 |
-| pd.UInt8Dtype, pd.UInt16Dtype, pd.UInt32Dtype | "unsigned" int      |
-| pd.Int64Dtype                                 | long                |
-| pd.UInt64Dtype                                | "unsigned" long     |
+| pd.Int8Dtype, pd.Int16Dtype, pd.Int32Dtype*   | int                 |
+| pd.UInt8Dtype, pd.UInt16Dtype, pd.UInt32Dtype*| "unsigned" int      |
+| pd.Int64Dtype*                                | long                |
+| pd.UInt64Dtype*                               | "unsigned" long     |
+/ pd.StringDtype**                              / string              /
+/ pd.BooleanDtype**                             / boolean             /
 
-Pandas 0.24 added support for nullable integers, which we can easily represent in Avro. We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.
+\* Pandas 0.24 added support for nullable integers, which we can easily represent in Avro. We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.
+
+\** Pandas 1.0.0 added support for nullable string and boolean datatypes.
 
 And these logical types:
 
@@ -59,6 +63,10 @@ Note that the timestamp must not contain any timezone (it must be naive) because
 
 If you don't want pandavro to infer this schema but instead define it yourself, pass it using the `schema` kwarg to `to_avro`.
 
+## Loading Pandas nullable datatypes
+The nullable datatypes indicated in the table above are easily written to Avro, but loading them introduces ambiguity as we can use either the old, default or these new datatypes. We solve this by using a special keyword when loading to force conversion to these new NA-supporting datatypes (`support_na=True`).
+
+This is *different* from [convert_dtypes](https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#convert-dtypes-method-to-ease-use-of-supported-extension-dtypes) as it does not infer the datatype based on the actual values, but it looks at the Avro schema so is deterministic and not dependent on the actual values.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@ Note that the timestamp must not contain any timezone (it must be naive) because
 If you don't want pandavro to infer this schema but instead define it yourself, pass it using the `schema` kwarg to `to_avro`.
 
 ## Loading Pandas nullable datatypes
-The nullable datatypes indicated in the table above are easily written to Avro, but loading them introduces ambiguity as we can use either the old, default or these new datatypes. We solve this by using a special keyword when loading to force conversion to these new NA-supporting datatypes (`support_na=True`).
+The nullable datatypes indicated in the table above are easily written to Avro, but loading them introduces ambiguity as we can use either the old, default or these new datatypes. We solve this by using a special keyword when loading to force conversion to these new NA-supporting datatypes:
+
+```python
+import pandavro as pdx
+
+# Load datatypes as NA-compatible datatypes where possible
+pdx.read_avro(path, na_dtypes=True)
+```
 
 This is *different* from [convert_dtypes](https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#convert-dtypes-method-to-ease-use-of-supported-extension-dtypes) as it does not infer the datatype based on the actual values, but it looks at the Avro schema so is deterministic and not dependent on the actual values.
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@ OUTPUT_PATH='{}/example.avro'.format(os.path.dirname(__file__))
 def main():
     df = pd.DataFrame({
         "Boolean": [True, False, True, False],
-        "pdBoolean": pd.Series([True, False, True, False, True, None, True, False], dtype=pd.BooleanDtype()),
+        "pdBoolean": pd.Series([True, None, True, False], dtype=pd.BooleanDtype()),
         "Float64": np.random.randn(4),
         "Int64": np.random.randint(0, 10, 4),
-        "pdInt64":  pd.Series(list(np.random.randint(0, 10, 7)) + [None], dtype=pd.Int64Dtype()),
+        "pdInt64":  pd.Series(list(np.random.randint(0, 10, 3)) + [None], dtype=pd.Int64Dtype()),
         "String": ['foo', 'bar', 'foo', 'bar'],
-        "pdString": pd.Series(['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar'], dtype=pd.StringDtype()),
+        "pdString": pd.Series(['foo', 'bar', 'foo', None], dtype=pd.StringDtype()),
         "DateTime64": [pd.Timestamp('20190101'), pd.Timestamp('20190102'),
                        pd.Timestamp('20190103'), pd.Timestamp('20190104')]
     })

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Pandavro can handle these primitive types:
 | pd.UInt8Dtype, pd.UInt16Dtype, pd.UInt32Dtype*| "unsigned" int      |
 | pd.Int64Dtype*                                | long                |
 | pd.UInt64Dtype*                               | "unsigned" long     |
-/ pd.StringDtype**                              / string              /
-/ pd.BooleanDtype**                             / boolean             /
+| pd.StringDtype**                              | string              |
+| pd.BooleanDtype**                             | boolean             |
 
 \* Pandas 0.24 added support for nullable integers, which we can easily represent in Avro. We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.
 

--- a/README.md
+++ b/README.md
@@ -40,28 +40,29 @@ Pandavro can handle these primitive types:
 | np.unicode_                                   | string              |
 | np.object_                                    | string              |
 | np.int8, np.int16, np.int32                   | int                 |
-| np.uint8, np.uint16, np.uint32                | int                 |
-| np.int64, np.uint64                           | long                |
-| pd.Int8Dtype, pd.Int16Dtype, pd.Int32Dtype*   | int                 |
-| pd.UInt8Dtype, pd.UInt16Dtype, pd.UInt32Dtype*| "unsigned" int      |
-| pd.Int64Dtype*                                | long                |
-| pd.UInt64Dtype*                               | "unsigned" long     |
+| np.uint8, np.uint16, np.uint32                | "unsigned" int*     |
+| np.uint64                                     | "unsigned" long*    |
+| np.int64, pd.Int64Dtype                       | long                |
+| pd.Int8Dtype, pd.Int16Dtype, pd.Int32Dtype    | int                 |
+| pd.UInt8Dtype, pd.UInt16Dtype, pd.UInt32Dtype | "unsigned" int*     |
 | pd.StringDtype**                              | string              |
 | pd.BooleanDtype**                             | boolean             |
 
-\* Pandas 0.24 added support for nullable integers, which we can easily represent in Avro. We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.
+\* We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.  Pandas 0.24 added support for nullable integers. Writing `pd.UInt64Dtype` is not supported by fastavro.
 
 \** Pandas 1.0.0 added support for nullable string and boolean datatypes.
 
-And these logical types:
+Pandavro also supports these logical types:
 
-| Numpy/pandas type                               | Avro logical type |
-|-------------------------------------------------|-------------------|
-| np.datetime64, pd.DatetimeTZDtype, pd.Timestamp | timestamp-micros  |
+| Numpy/pandas type                               | Avro logical type  |
+|-------------------------------------------------|--------------------|
+| np.datetime64, pd.DatetimeTZDtype, pd.Timestamp | timestamp-micros*  |
 
-Note that the timestamp must not contain any timezone (it must be naive) because Avro does not support timezones.
+\* If passed `to_avro(..., times_as_micros=False)`, this has a millisecond resolution.
 
-If you don't want pandavro to infer this schema but instead define it yourself, pass it using the `schema` kwarg to `to_avro`.
+Due to [an inherent design choice in fastavro](https://github.com/fastavro/fastavro/issues/409), it interprets a *naive* datetime in the system's timezone before serializing it. This has the consequence that your *naive* datetime will not correctly roundtrip to and from an Avro file. *Always indicate a timezone* to avoid the system timezone introducing problems.
+
+If you don't want pandavro to infer the schema but instead define it yourself, pass it using the `schema` kwarg to `to_avro`.
 
 ## Loading Pandas nullable datatypes
 The nullable datatypes indicated in the table above are easily written to Avro, but loading them introduces ambiguity as we can use either the old, default or these new datatypes. We solve this by using a special keyword when loading to force conversion to these new NA-supporting datatypes:
@@ -75,10 +76,11 @@ pdx.read_avro(path, na_dtypes=True)
 
 This is *different* from [convert_dtypes](https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#convert-dtypes-method-to-ease-use-of-supported-extension-dtypes) as it does not infer the datatype based on the actual values, but it looks at the Avro schema so is deterministic and not dependent on the actual values.
 
-## Timezones
-Due to [an inherent design choice in fastavro](https://github.com/fastavro/fastavro/issues/409), it interprets a *naive* datetime in the system's timezone before serializing it. This has the consequence that your *naive* datetime will not correctly roundtrip to and from an Avro file. Always indicate a timezone to avoid the system timezone introducing problems.
+Also note that, in "normal" mode, numpy int/uint dtypes are all read back as `np.int64` due to how fastavro reads them. (This could be worked around by converting type after loading, PRs welcome.) In `na_dtypes=True` mode they are loaded correctly as Pandas NA-dtypes, but with no less than 32 bits of resolution (less is not supported by Avro so we can not infer it from the schema).
 
 ## Example
+
+See `tests/pandavro_test.py` for more examples.
 
 ```python
 import os
@@ -90,12 +92,17 @@ OUTPUT_PATH='{}/example.avro'.format(os.path.dirname(__file__))
 
 
 def main():
-    df = pd.DataFrame({"Boolean": [True, False, True, False],
-                       "Float64": np.random.randn(4),
-                       "Int64": np.random.randint(0, 10, 4),
-                       "String": ['foo', 'bar', 'foo', 'bar'],
-                       "DateTime64": [pd.Timestamp('20190101'), pd.Timestamp('20190102'),
-                                      pd.Timestamp('20190103'), pd.Timestamp('20190104')]})
+    df = pd.DataFrame({
+        "Boolean": [True, False, True, False],
+        "pdBoolean": pd.Series([True, False, True, False, True, None, True, False], dtype=pd.BooleanDtype()),
+        "Float64": np.random.randn(4),
+        "Int64": np.random.randint(0, 10, 4),
+        "pdInt64":  pd.Series(list(np.random.randint(0, 10, 7)) + [None], dtype=pd.Int64Dtype()),
+        "String": ['foo', 'bar', 'foo', 'bar'],
+        "pdString": pd.Series(['foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar'], dtype=pd.StringDtype()),
+        "DateTime64": [pd.Timestamp('20190101'), pd.Timestamp('20190102'),
+                       pd.Timestamp('20190103'), pd.Timestamp('20190104')]
+    })
 
     pdx.to_avro(OUTPUT_PATH, df)
     saved = pdx.read_avro(OUTPUT_PATH)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ The nullable datatypes indicated in the table above are easily written to Avro, 
 
 This is *different* from [convert_dtypes](https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#convert-dtypes-method-to-ease-use-of-supported-extension-dtypes) as it does not infer the datatype based on the actual values, but it looks at the Avro schema so is deterministic and not dependent on the actual values.
 
+## Timezones
+Due to [an inherent design choice in fastavro](https://github.com/fastavro/fastavro/issues/409), it interprets a *naive* datetime in the system's timezone before serializing it. This has the consequence that your *naive* datetime will not correctly roundtrip to and from an Avro file. Always indicate a timezone to avoid the system timezone introducing problems.
+
 ## Example
 
 ```python

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -104,7 +104,7 @@ def __type_infer(t):
 
 def __fields_infer(df):
     return [
-        {'name': key, 'type': __type_infer(type_np, key=key)}
+        {'name': key, 'type': __type_infer(type_np)}
         for key, type_np in six.iteritems(df.dtypes)
     ]
 

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -142,7 +142,7 @@ def __file_to_dataframe(f, schema, na_dtypes=False, **kwargs):
         else:
             l = [t for t in typelist if t != "null"]
             if len(l) > 1:
-                raise ValueError(f"More items in list than 1. {l}")
+                raise ValueError("More items in Avro schema type list than 1: '{d}'".format(l))
             return _filter(l[0])
 
     if na_dtypes:

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -219,6 +219,8 @@ def to_avro(file_path_or_buffer, df, schema=None, append=False,
         schema: Dict of Avro schema.
             If it's set None, inferring schema.
         append: Boolean to control if will append to existing file
+        times_as_micros: If True (default), save datetimes with microseconds resolution. If False, save with millisecond
+            resolution instead.
         kwargs: Keyword arguments to fastavro.writer
 
     """

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -74,7 +74,6 @@ except AttributeError:
 def __type_infer(t):
     # Binary data has to be handled separately from the other dtypes because it
     # requires a parameter, the buffer size.
-    print(t)
     if t is np.void:
         return {
             'type': ['null', 'fixed'],

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -160,5 +160,28 @@ def test_advanced_dtypes(dataframe_na_dtypes):
     assert_frame_equal(expect, df)
 
 
+def test_benchmark_advanced_dtypes(dataframe):
+    "Should not be much slower for basic dtype dataframes with Pandas NA-dtypes preprocessing"
+    import timeit
+    reps = 1000
+
+    t1 = timeit.timeit(
+        "pdx.to_avro(filename, df)",
+        globals=dict(pdx=pdx, filename=NamedTemporaryFile().name, df=dataframe),
+        number=reps
+    )
+
+    t2 = timeit.timeit(
+        "pdx.to_avro(filename, df, _test_preprocess_off=True)",
+        globals=dict(pdx=pdx, filename=NamedTemporaryFile().name, df=dataframe),
+        number=reps
+    )
+
+    # 20% was arbitrarily chosen to give some leeway in this slightly random benchmark
+    # Observed differences are very small
+    assert abs(t1 - t2) / min(t1, t2) < .2, "Performance difference is not below 20%, " \
+                                            "{:.3f}s with and {:.3f}s without".format(t1, t2)
+
+
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
This PR adds the capability to both write and read Pandas NA-dtypes. Writing Panda's Int types was already implemented, now we can also convert to those on reading, and writing/reading the new Pandas 1.0 datatypes is now also possible.

Note: Tests are working but it's still a bit messy. Should be cleaned up, but wanted to get this PR out to show the concept and get some feedback.

## The basic idea
Please see the updated README for basic usage.

Writing the Pandas Boolean, String and Int datatypes is not that hard: just add them to the dictionary that maps python/numpy/pandas types to Avro types. We do need a bit of extra conversion for the Boolean, Int types as fastavro cannot write the `pd.NA` value, so we convert right before writing. But that's basically all there is to it.

Reading is another story, as we can suddenly read either as "old" numpy datatypes or as "new". To toggle between these two option, the flag `na_dtypes` is added to `read_avro()`. We can do this by going through the Avro schema and seeing where we can apply this inverse mapping. We need to do this after loading the dataframe with Pandas, as it by default loads everything as "old" datatypes. So we are just converting dtypes after the fact based on the Avro schema. This allows us to avoid the nondeterministic nature of [df.convert_dtypes()](https://pandas.pydata.org/docs/whatsnew/v1.0.0.html#convert-dtypes-method-to-ease-use-of-supported-extension-dtypes). This is not something that can easily be implemented after loading outside of Pandavro, as we need the Avro schema to do this deterministic mapping.