### PR TITLE
Adding 'Record' and 'Array' Complex Types to Schema Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It prepares like pandas APIs:
     - Read the records from Avro file and fit them into pandas DataFrame using [fastavro](https://github.com/tebeka/fastavro).
 - `to_avro`
     - Write the rows of pandas DataFrame to Avro file with the original schema infer.
-    
+
 ## What can and can't pandavro do?
 
 Avro can represent the following kinds of types:
@@ -49,13 +49,35 @@ Pandavro can handle these primitive types:
 
 Pandas 0.24 added support for nullable integers, which we can easily represent in Avro. We represent the unsigned versions of these integers by adding the non-standard "unsigned" flag as such: `{'type': 'int', 'unsigned': True}`.
 
+If a boolean column includes empty values, pandas classifies the column as having a dtype of `object` - this is accounted for in complex column handling.
+
+
+And these complex types - all complex types will be classified by pandas as having a dtype of `object`, so their underlying python types are used to determine the Avro type:
+
+| Python type                                   | Avro complex type   |
+|-----------------------------------------------|---------------------|
+| dict, collections.OrderedDict                 | record              |
+| list                                          | array               |
+
+Record and array types can be arbitrarily nested within each other.
+
+The schema definition of a record requires a unique name for the record separate from the column itself. This does not map to any concept in pandas, so for this we just append '_record' to the original column name and a number to ensure that there are zero duplicate 'name' values.
+
+The remaining Avro complex types are not currently supported for the following reasons:
+1. Enum: The closest pandas type to Avro's enum type is `pd.Categorical`, but it still is not a complete match. Possible values of the enum type can only be alphanumeric strings, whereas `pd.Categorical` values have no such limitation.
+2. Map: No strictly matching concept in Python/pandas - Python dictionaries can have arbitrarily typed keys. Functionality can be essentially be achieved with the record type.
+3. Union: Any column with mixed types (other than empty values/`NoneType`) are treated by pandas as having a dtype of `object`, and will be written as strings. It would be difficult to deterministically infer multiple allowed data types based solely on a column's contents.
+4. Fixed: There is no immediately equivalent Python/pandas type for binary data. The data in some columns could be translated to binary data (such as with `int.to_bytes()`), but pandavro would need to be instructed on which columns to translate and which to leave alone. This would add a great deal of complexity to the code - certainly more complexity than just saving the binary data as strings.
+
+
 And these logical types:
 
-| Numpy/pandas type                               | Avro logical type |
-|-------------------------------------------------|-------------------|
-| np.datetime64, pd.DatetimeTZDtype, pd.Timestamp | timestamp-micros  |
+| Numpy/pandas type                               | Avro logical type                 |
+|-------------------------------------------------|-----------------------------------|
+| np.datetime64, pd.DatetimeTZDtype, pd.Timestamp | timestamp-micros/timezone-millis  |
 
 Note that the timestamp must not contain any timezone (it must be naive) because Avro does not support timezones.
+Timestamps are encoded as microseconds by default, but can be encoded in milliseconds by using `times_as_micros=False`
 
 If you don't want pandavro to infer this schema but instead define it yourself, pass it using the `schema` kwarg to `to_avro`.
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Pandas 0.24 added support for nullable integers, which we can easily represent i
 If a boolean column includes empty values, pandas classifies the column as having a dtype of `object` - this is accounted for in complex column handling.
 
 
-And these complex types - all complex types will be classified by pandas as having a dtype of `object`, so their underlying python types are used to determine the Avro type:
+And these complex types - all complex types other than 'fixed' will be classified by pandas as having a dtype of `object`, so their underlying python types are used to determine the Avro type:
 
-| Python type                                   | Avro complex type   |
-|-----------------------------------------------|---------------------|
-| dict, collections.OrderedDict                 | record              |
-| list                                          | array               |
+| Numpy/Python type             | Avro complex type |
+|-------------------------------|-------------------|
+| dict, collections.OrderedDict | record            |
+| list                          | array             |
+| np.void                       | fixed             |
 
 Record and array types can be arbitrarily nested within each other.
 
@@ -67,7 +68,6 @@ The remaining Avro complex types are not currently supported for the following r
 1. Enum: The closest pandas type to Avro's enum type is `pd.Categorical`, but it still is not a complete match. Possible values of the enum type can only be alphanumeric strings, whereas `pd.Categorical` values have no such limitation.
 2. Map: No strictly matching concept in Python/pandas - Python dictionaries can have arbitrarily typed keys. Functionality can be essentially be achieved with the record type.
 3. Union: Any column with mixed types (other than empty values/`NoneType`) are treated by pandas as having a dtype of `object`, and will be written as strings. It would be difficult to deterministically infer multiple allowed data types based solely on a column's contents.
-4. Fixed: There is no immediately equivalent Python/pandas type for binary data. The data in some columns could be translated to binary data (such as with `int.to_bytes()`), but pandavro would need to be instructed on which columns to translate and which to leave alone. This would add a great deal of complexity to the code - certainly more complexity than just saving the binary data as strings.
 
 
 And these logical types:

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -119,7 +119,7 @@ def __complex_field_infer(df, field, nested_record_names):
         }
 
 
-def __fields_infer(df, nested_record_names={}):
+def __fields_infer(df, nested_record_names):
     inferred_fields = [
         {'name': key, 'type': __type_infer(type_np)}
         for key, type_np in six.iteritems(df.dtypes)
@@ -159,7 +159,7 @@ def schema_infer(df, times_as_micros=True):
             Whether timestamps should be stored as microseconds (default)
             or milliseconds (as expected by Apache Hive)
     """
-    fields = __fields_infer(df)
+    fields = __fields_infer(df, {})
     schema = {
         'type': 'record',
         'name': 'Root',

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -31,7 +31,8 @@ NUMPY_TO_AVRO_TYPES = {
     pd.Timestamp: {'type': 'long', 'logicalType': 'timestamp-micros'},
 }
 
-# Pandas 0.24 added support for nullable integers. Include those in the supported integer dtypes if present, otherwise ignore them.
+# Pandas 0.24 added support for nullable integers. Include those in the supported
+# integer dtypes if present, otherwise ignore them.
 try:
     NUMPY_TO_AVRO_TYPES[pd.Int8Dtype] = 'int'
     NUMPY_TO_AVRO_TYPES[pd.Int16Dtype] = 'int'

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import pprint
 
 import fastavro
 import numpy as np
@@ -73,41 +72,64 @@ def __type_infer(t):
     raise TypeError('Invalid type: {}'.format(t))
 
 
-def __complex_field_infer(df, field):
+def __complex_field_infer(df, field, nested_record_names):
     NoneType = type(None)
+    bool_types = {bool, NoneType}
     string_types = {str, NoneType}
     record_types = {dict, OrderedDict, NoneType}
     array_types = {list, NoneType}
 
     base_field_types = set(df[field].apply(type))
-    # String type
+
+    # Bool type - if a boolean field contains missing values, pandas will give
+    # its type as np.dtype('O'), so we have to double check for it here.
+    if base_field_types.issubset(bool_types):
+        return 'boolean'
     if base_field_types.issubset(string_types):
-        return {'type': 'string'}
+        return 'string'
     # Record type
     elif base_field_types.issubset(record_types):
-        records = df.loc[~df[field].isna(), field]
+        records = df.loc[~df[field].isna(), field].reset_index(drop=True)
+
+        if field in nested_record_names:
+            nested_record_names[field] += 1
+        else:
+            nested_record_names[field] = 0
         return {
             'type': 'record',
-            'name': field + '_record',
-            'fields': __fields_infer(pd.DataFrame.from_records(records))
+            'name': field + '_record' + str(nested_record_names[field]),
+            'fields': __fields_infer(pd.DataFrame.from_records(records),
+                                     nested_record_names)
         }
     # Array type
     elif base_field_types.issubset(array_types):
-        arrays = pd.Series(df.loc[~df[field].isna(), field].sum(), name=field)
+        arrays = pd.Series(df.loc[~df[field].isna(), field].sum(),
+                           name=field).reset_index(drop=True)
+        if arrays.empty:
+            print('Array field \'{}\' has been provided containing only empty '
+                  'lists. The intended type of its contents cannot be '
+                  'inferred, so \'string\' was assumed.'.format(field))
+            items = 'string'
+        else:
+            items = __fields_infer(arrays.to_frame(),
+                                   nested_record_names)[0]['type']
         return {
             'type': 'array',
-            'items': __fields_infer(arrays.to_frame())[0]['type']
+            'items': items
         }
 
 
-def __fields_infer(df):
+def __fields_infer(df, nested_record_names={}):
     inferred_fields = [
         {'name': key, 'type': __type_infer(type_np)}
         for key, type_np in six.iteritems(df.dtypes)
     ]
     for field in inferred_fields:
         if 'complex' in field['type']:
-            field['type'] = ['null', __complex_field_infer(df, field['name'])]
+            field['type'] = [
+                'null',
+                __complex_field_infer(df, field['name'], nested_record_names)
+            ]
     return inferred_fields
 
 
@@ -127,7 +149,16 @@ def __convert_field_micros_to_millis(field):
             return field
 
 
-def __schema_infer(df, times_as_micros):
+def schema_infer(df, times_as_micros=True):
+    """
+    Infers the Avro schema of a pandas DataFrame
+
+    Args:
+        df: DataFrame to infer the schema of
+        times_as_micros:
+            Whether timestamps should be stored as microseconds (default)
+            or milliseconds (as expected by Apache Hive)
+    """
     fields = __fields_infer(df)
     schema = {
         'type': 'record',
@@ -137,10 +168,8 @@ def __schema_infer(df, times_as_micros):
 
     # Patch 'timestamp-millis' in
     if not times_as_micros:
-        pprint.pprint(schema)
         for field in schema['fields']:
             field = __convert_field_micros_to_millis(field)
-    pprint.pprint(schema)
     return schema
 
 
@@ -197,11 +226,14 @@ def to_avro(file_path_or_buffer, df, schema=None, append=False,
         schema: Dict of Avro schema.
             If it's set None, inferring schema.
         append: Boolean to control if will append to existing file
+        times_as_micros:
+            Whether timestamps should be stored as microseconds (default)
+            or milliseconds (as expected by Apache Hive)
         kwargs: Keyword arguments to fastavro.writer
 
     """
     if schema is None:
-        schema = __schema_infer(df, times_as_micros)
+        schema = schema_infer(df, times_as_micros)
 
     open_mode = 'wb' if not append else 'a+b'
 

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -84,6 +84,7 @@ def __complex_field_infer(df, field, nested_record_names):
     # its type as np.dtype('O'), so we have to double check for it here.
     if base_field_types.issubset(bool_types):
         return 'boolean'
+    # String type
     if base_field_types.issubset(string_types):
         return 'string'
     # Record type

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -80,13 +80,14 @@ def __complex_field_infer(df, field, nested_record_names):
 
     base_field_types = set(df[field].apply(type))
 
+    # String type - have to check for string first, in case a column contains
+    # entirely 'None's
+    if base_field_types.issubset(string_types):
+        return 'string'
     # Bool type - if a boolean field contains missing values, pandas will give
     # its type as np.dtype('O'), so we have to double check for it here.
     if base_field_types.issubset(bool_types):
         return 'boolean'
-    # String type
-    if base_field_types.issubset(string_types):
-        return 'string'
     # Record type
     elif base_field_types.issubset(record_types):
         records = df.loc[~df[field].isna(), field].reset_index(drop=True)

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -7,8 +7,7 @@ import six
 
 try:
     # Pandas <= 0.23
-    from pandas.core.dtypes.dtypes import (
-        DatetimeTZDtypeType as DatetimeTZDtype)
+    from pandas.core.dtypes.dtypes import DatetimeTZDtypeType as DatetimeTZDtype
 except ImportError:
     # Pandas >= 0.24
     from pandas import DatetimeTZDtype
@@ -32,8 +31,7 @@ NUMPY_TO_AVRO_TYPES = {
     pd.Timestamp: {'type': 'long', 'logicalType': 'timestamp-micros'},
 }
 
-# Pandas 0.24 added support for nullable integers. Include those in the
-# supported integer dtypes if present, otherwise ignore them.
+# Pandas 0.24 added support for nullable integers. Include those in the supported integer dtypes if present, otherwise ignore them.
 try:
     NUMPY_TO_AVRO_TYPES[pd.Int8Dtype] = 'int'
     NUMPY_TO_AVRO_TYPES[pd.Int16Dtype] = 'int'

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pandavro as pdx
 from tempfile import NamedTemporaryFile
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 from io import BytesIO
 
 
@@ -33,7 +33,7 @@ def test_schema_infer(dataframe):
                 {'type': ['null', 'string'], 'name': 'String'},
             ]
     }
-    assert expect == pdx.__schema_infer(dataframe, times_as_micros=True)
+    assert expect == pdx.schema_infer(dataframe, times_as_micros=True)
 
 
 def test_schema_infer_times_as_millis(dataframe):
@@ -50,8 +50,45 @@ def test_schema_infer_times_as_millis(dataframe):
                 {'type': ['null', 'string'], 'name': 'String'},
             ]
     }
-    assert expect == pdx.__schema_infer(dataframe, times_as_micros=False)
+    assert expect == pdx.schema_infer(dataframe, times_as_micros=False)
 
+
+def test_schema_infer_complex_types(dataframe):
+    expect = {
+        'type': 'record',
+        'name': 'Root',
+        'fields':
+            [
+                {'type': ['null', 'boolean'], 'name': 'Boolean'},
+                {'type': ['null', {'logicalType': 'timestamp-micros', 'type': 'long'}],
+                    'name': 'DateTime64'},
+                {'type': ['null', 'double'], 'name': 'Float64'},
+                {'type': ['null', 'long'], 'name': 'Int64'},
+                {'type': ['null', 'string'], 'name': 'String'},
+                {'type': ['null', {
+                    'fields':
+                        [
+                            {'name': 'field1', 'type': ['null', 'long']},
+                            {'name': 'field2', 'type': ['null', 'string']}
+                        ],
+                    'name': 'Record_record0',
+                    'type': 'record'}],
+                 'name': 'Record'},
+                {'type': ['null', {'type': 'array', 'items': ['null', 'long']}],
+                 'name': 'Array'}
+            ]
+    }
+    print(dataframe)
+    dataframe["Record"] = [
+        {'field1': 1, 'field2': 'str1'}, {'field1': 2, 'field2': 'str2'},
+        {'field1': 3, 'field2': 'str3'}, {'field1': 4, 'field2': 'str4'},
+        {'field1': 5, 'field2': 'str5'}, {'field1': 6, 'field2': 'str6'},
+        {'field1': 7, 'field2': 'str7'}, {'field1': 8, 'field2': 'str8'}]
+    dataframe["Array"] = [
+        [1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14], [15, 16]
+    ]
+
+    assert expect == pdx.schema_infer(dataframe, times_as_micros=True)
 
 def test_fields_infer(dataframe):
     expect = [

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -78,7 +78,6 @@ def test_schema_infer_complex_types(dataframe):
                  'name': 'Array'}
             ]
     }
-    print(dataframe)
     dataframe["Record"] = [
         {'field1': 1, 'field2': 'str1'}, {'field1': 2, 'field2': 'str2'},
         {'field1': 3, 'field2': 'str3'}, {'field1': 4, 'field2': 'str4'},
@@ -100,7 +99,7 @@ def test_fields_infer(dataframe):
         {'type': ['null', 'long'], 'name': 'Int64'},
         {'type': ['null', 'string'], 'name': 'String'},
     ]
-    assert expect == pdx.__fields_infer(dataframe)
+    assert expect == pdx.__fields_infer(dataframe, nested_record_names={})
 
 
 def test_buffer_e2e(dataframe):

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -90,6 +90,7 @@ def test_schema_infer_complex_types(dataframe):
 
     assert expect == pdx.schema_infer(dataframe, times_as_micros=True)
 
+
 def test_fields_infer(dataframe):
     expect = [
         {'type': ['null', 'boolean'], 'name': 'Boolean'},


### PR DESCRIPTION
Adding support for the Avro complex types 'record' and 'array'. Other complex types are not included for reasons included in `README.md`.

The one area of this code I am not thrilled with is the changed method of switching 'timestamp-micros' to 'timestamp-millis'. Since the `logicalType` value in the schema can now be arbitrarily deeply nested in lists and dictionaries, it is not as simple as just checking each top-level field for a `logicalType` value and modifying it accordingly. The cleanest solution I could think of was to just iterate over the entire top-level `fields` list. I would be happy to hear out suggestions for a prettier way of doing this.

Additionally, I made `schema_infer` into a public method, because there are a number of scenarios where a user may just wish to generate the schema for a DataFrame without immediately writing it to a file. In my use case, I want to access the schema so I may insert it directly into table metadata in Apache Hive.