### PR TITLE
read_avro: optimized support for columns argument

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from pathlib import Path
+from typing import Optional, Iterable
 
 import fastavro
 import numpy as np
@@ -183,7 +184,7 @@ def schema_infer(df, times_as_micros=True):
     return schema
 
 
-def __file_to_dataframe(f, schema, na_dtypes=False, columns=None, **kwargs):
+def __file_to_dataframe(f, schema, na_dtypes=False, columns: Optional[Iterable[str]] = None, **kwargs):
     reader = fastavro.reader(f, reader_schema=schema)
     if columns is None:
         records = list(reader)
@@ -191,6 +192,7 @@ def __file_to_dataframe(f, schema, na_dtypes=False, columns=None, **kwargs):
     else:
         columns_set = frozenset(columns)
         records = [{k: v for k, v in row.items() if k in columns_set} for row in reader]
+
     df = pd.DataFrame.from_records(records, columns=columns, **kwargs)
 
     def _filter(typelist):
@@ -228,7 +230,7 @@ def __file_to_dataframe(f, schema, na_dtypes=False, columns=None, **kwargs):
     return df
 
 
-def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, columns=None, **kwargs):
+def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, columns: Optional[Iterable[str]] = None, **kwargs):
     """
     Avro file reader.
 

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -183,9 +183,15 @@ def schema_infer(df, times_as_micros=True):
     return schema
 
 
-def __file_to_dataframe(f, schema, na_dtypes=False, **kwargs):
+def __file_to_dataframe(f, schema, na_dtypes=False, columns=None, **kwargs):
     reader = fastavro.reader(f, reader_schema=schema)
-    df = pd.DataFrame.from_records(list(reader), **kwargs)
+    if columns is None:
+        records = list(reader)
+    # To free up some RAM we can select a subset of columns
+    else:
+        columns_set = frozenset(columns)
+        records = [{k: v for k, v in row.items() if k in columns_set} for row in reader]
+    df = pd.DataFrame.from_records(records, columns=columns, **kwargs)
 
     def _filter(typelist):
         # It's a string, we return it directly
@@ -222,7 +228,7 @@ def __file_to_dataframe(f, schema, na_dtypes=False, **kwargs):
     return df
 
 
-def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, **kwargs):
+def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, columns=None, **kwargs):
     """
     Avro file reader.
 
@@ -230,6 +236,7 @@ def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, **kwargs):
         file_path_or_buffer: Input file path (str or pathlib.Path) or file-like object.
         schema: Avro schema.
         na_dtypes: Read int, long, string, boolean types back as Pandas NA-supporting datatypes.
+        columns: Sequence, subset of columns to load in memory.
         **kwargs: Keyword argument to pandas.DataFrame.from_records.
 
     Returns:
@@ -242,9 +249,11 @@ def read_avro(file_path_or_buffer, schema=None, na_dtypes=False, **kwargs):
 
     if isinstance(file_path_or_buffer, str):
         with open(file_path_or_buffer, 'rb') as f:
-            return __file_to_dataframe(f, schema, na_dtypes=na_dtypes, **kwargs)
+            return __file_to_dataframe(f, schema, na_dtypes=na_dtypes, columns=columns, **kwargs)
     else:
-        return __file_to_dataframe(file_path_or_buffer, schema, na_dtypes=na_dtypes, **kwargs)
+        return __file_to_dataframe(
+            file_path_or_buffer, schema, na_dtypes=na_dtypes, columns=columns, **kwargs
+        )
 
 
 def from_avro(file_path_or_buffer, schema=None, na_dtypes=False, **kwargs):

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -153,14 +153,18 @@ def test_append(dataframe):
     assert_frame_equal(expect, dataframe)
 
 
-def test_dataframe_kwargs(dataframe):
+def test_dataframe_subset_columns(dataframe):
     tf = NamedTemporaryFile()
     pdx.to_avro(tf.name, dataframe)
-    # include columns
-    columns = ['Boolean', 'Int64']
+    columns = ['Boolean', 'Int64', 'String']
     expect = pdx.read_avro(tf.name, columns=columns)
     df = dataframe[columns]
     assert_frame_equal(expect, df)
+
+
+def test_dataframe_kwargs(dataframe):
+    tf = NamedTemporaryFile()
+    pdx.to_avro(tf.name, dataframe)
     # exclude columns
     columns = ['String', 'Boolean']
     expect = pdx.read_avro(tf.name, exclude=columns)


### PR DESCRIPTION
Hello,

Here is a small change suggestion, in order to reduce memory usage of `read_avro` in some cases. Now only loads in memory the columns we want to keep.

Done with @FloChehab