### PR TITLE
Loosen the pinned fastavro dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages(exclude=['example']),
     install_requires=[
         # fixed versions.
-        'fastavro==1.5.1',
+        'fastavro~=1.5.1',
         'pandas>=1.1',
         # https://pandas.pydata.org/pandas-docs/version/1.1/getting_started/install.html#dependencies
         'numpy>=1.15.4',


### PR DESCRIPTION
Previously the `fastavro` dependency was pinned to exactly match v1.5.1.

This would make pandavro unable to coexists with other libraries that depend on even slightly newer versions of fastavro, for example [marcosschroh/dataclasses-avroschema](https://github.com/marcosschroh/dataclasses-avroschema)], which requires fastavro v1.5.4.

Loosening this dependency to `~=1.5.1` should allow pandavro to continue working with newer versions of fastavro up until a major version increment.

Tests still appear to pass.