### PR TITLE
Support python 3.11 & update test / CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,18 +16,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .[tests]
-    - name: Test with pytest
-      run: |
-        pytest -v tests
+        python -m pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox p

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+We provide a Makefile to ease with setting up a development environment.
+
+- `make init` will setup a simple python virtual env and install the package
+- `make test` will run the test suite with the current environment
+- `make test-all` will run all the tests accross different environments with `tox`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+SHELL = /bin/bash
+
+.DEFAULT_GOAL := all
+
+## help: Display list of commands
+.PHONY: help
+help: Makefile
+	@sed -n 's|^##||p' $< | column -t -s ':' | sed -e 's|^| |'
+
+## all: Run all targets
+.PHONY: all
+all: init style test
+
+## init: Bootstrap dev env.
+.PHONY: init
+init:
+	python3 -m venv ./venv
+	./venv/bin/pip install -e .[tests]
+
+## test: Shortcut to launch all the test on all environments
+.PHONY: test
+test:
+	./venv/bin/pytest
+
+## test-all: Shortcut to launch all the test on all environments
+.PHONY: test-all
+test-all:
+	./venv/bin/tox p
+
+## clean: Remove temporary files
+.PHONY: clean
+clean:
+	-rm -rf .mypy_cache ./**/.pytest_cache venv

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,14 @@ setup(
     packages=find_packages(exclude=['example']),
     install_requires=[
         # fixed versions.
-        'fastavro~=1.5.1',
+        'fastavro>=1.5.1,<2.0.0',
         'pandas>=1.1',
         # https://pandas.pydata.org/pandas-docs/version/1.1/getting_started/install.html#dependencies
         'numpy>=1.15.4',
     ],
     extras_require={
-        'tests': ['pytest==7.1.2'],
+        'tests': ['pytest==7.3.2', 'tox==4.6.0'],
     },
     # https://pandas.pydata.org/pandas-docs/version/1.1/getting_started/install.html#python-version-support
-    python_requires='>=3.6.1',
+    python_requires='>=3.7.0',
 )

--- a/tests/pandavro_test.py
+++ b/tests/pandavro_test.py
@@ -7,7 +7,13 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.util.testing import assert_frame_equal
+
+try:
+    # pandas >2.0
+    from pandas.testing import assert_frame_equal
+except ImportError:
+    # previous version of pandas
+    from pandas.util.testing import assert_frame_equal
 
 import pandavro as pdx
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist =
+    # pandas 2.0 doesn't support python 3.7
+    py37-pandas{1}-fastavro{15,16,17,1},
+    py{38,39,310,311}-pandas{1,2}-fastavro{15,16,17,1},
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+
+[testenv]
+deps =
+    pytest
+    pandas1: pandas >=1.1, <2
+    pandas2: pandas >=2.0.0, <3.0.0
+    fastavro15: fastavro >=1.5.1, <1.6.0
+    fastavro16: fastavro >=1.6.0, <1.7.0
+    fastavro17: fastavro >=1.7.0, <1.8.0
+    fastavro1: fastavro >=1.7.0, <2.0.0
+commands = pytest


### PR DESCRIPTION
Hello,
Quick PR because I really want pandavro to be compatible with python3.11.

* Also improved test setup to use tox and double check compatibilities of things
* Also updated Github CI to test on all supported python version and with tox
* Added a simple Makefile to ease with creating a dev env (and added a CONTRIBUTING.md)

Closes #44 
Closes #39

Also, this drops support for python 3.6 as it has reached EOL.
I haven't broken other dependency requirement (such as pandas 1.x).