### PR TITLE
fix(tests): tests only on fastavro versions that have wheels for python 3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     # pandas 2.0 doesn't support python 3.7
     py37-pandas{1}-fastavro{15,16,17,1},
-    py{38,39,310,311}-pandas{1,2}-fastavro{15,16,17,1},
+    py{38,39,310}-pandas{1,2}-fastavro{15,16,17,18,1},
+    py{311}-pandas{1,2}-fastavro{17,18,1},
 
 [gh-actions]
 python =
@@ -20,5 +21,6 @@ deps =
     fastavro15: fastavro >=1.5.1, <1.6.0
     fastavro16: fastavro >=1.6.0, <1.7.0
     fastavro17: fastavro >=1.7.0, <1.8.0
-    fastavro1: fastavro >=1.7.0, <2.0.0
+    fastavro18: fastavro >=1.8.0, <1.9.0
+    fastavro1: fastavro >=1.8.0, <2.0.0
 commands = pytest


### PR DESCRIPTION

* Also added tests on the latest fastavro version