### PR TITLE
Support numpy 2.0 and pandas 2.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pandavro can handle these primitive types:
 | np.bool_                                      | boolean             |
 | np.float32                                    | float               |
 | np.float64                                    | double              |
-| np.unicode_                                   | string              |
+| np.str_                                       | string              |
 | np.object_                                    | string              |
 | np.int8, np.int16, np.int32                   | int                 |
 | np.uint8, np.uint16, np.uint32                | "unsigned" int*     |

--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -19,7 +19,7 @@ NUMPY_TO_AVRO_TYPES = {
     np.int64: 'long',
     np.uint64: {'type': 'long', 'unsigned': True},
     np.dtype('O'): 'complex',  # FIXME: Don't automatically store objects as strings
-    np.unicode_: 'string',
+    np.str_: 'string',
     np.float32: 'float',
     np.float64: 'double',
     np.datetime64: {'type': 'long', 'logicalType': 'timestamp-micros'},

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,12 @@ setup(
     install_requires=[
         # fixed versions.
         'fastavro>=1.5.1,<2.0.0',
-        'pandas>=1.1',
-        # https://pandas.pydata.org/pandas-docs/version/1.1/getting_started/install.html#dependencies
-        'numpy>=1.15.4',
+        'pandas>=2.0,<3.0.0',
+        'numpy>=2.0',
     ],
     extras_require={
         'tests': ['pytest==7.3.2', 'tox==4.6.0'],
     },
     # https://pandas.pydata.org/pandas-docs/version/1.1/getting_started/install.html#python-version-support
-    python_requires='>=3.7.0',
+    python_requires='>=3.9.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         # fixed versions.
         'fastavro>=1.5.1,<2.0.0',
         'pandas>=2.0,<3.0.0',
-        'numpy>=2.0',
+        'numpy>=2.0,<3.0.0',
     ],
     extras_require={
         'tests': ['pytest==7.3.2', 'tox==4.6.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
 envlist =
-    # pandas 2.0 doesn't support python 3.7
-    py37-pandas{1}-fastavro{15,16,17,1},
-    py{38,39,310}-pandas{1,2}-fastavro{15,16,17,18,1},
-    py{311}-pandas{1,2}-fastavro{17,18,1},
+    py{39,310}-pandas{2}-fastavro{15,16,17,18,1},
+    py{311}-pandas{2}-fastavro{17,18,1},
     py{312}-pandas{2}-fastavro{18,1},
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
@@ -18,7 +14,6 @@ python =
 [testenv]
 deps =
     pytest
-    pandas1: pandas >=1.1, <2
     pandas2: pandas >=2.0.0, <3.0.0
     fastavro15: fastavro >=1.5.1, <1.6.0
     fastavro16: fastavro >=1.6.0, <1.7.0


### PR DESCRIPTION
Breaking Changes:

- Numpy 2.0 require Python >=3.9
- Drop support for Python 3.7 and 3.8

Close #56 