### PR TITLE
feat: Replace np.unicode_ with np.str_ to support NumPy 2.0

### DIFF
--- a/pandavro/__init__.py
+++ b/pandavro/__init__.py
@@ -19,7 +19,7 @@ NUMPY_TO_AVRO_TYPES = {
     np.int64: 'long',
     np.uint64: {'type': 'long', 'unsigned': True},
     np.dtype('O'): 'complex',  # FIXME: Don't automatically store objects as strings
-    np.unicode_: 'string',
+    np.str_: 'string',
     np.float32: 'float',
     np.float64: 'double',
     np.datetime64: {'type': 'long', 'logicalType': 'timestamp-micros'},


### PR DESCRIPTION
This change is to fix the below error

`np.unicode_` was removed in the NumPy 2.0 release. Use `np.str_` instead.
